### PR TITLE
added cookiecutter if-statement to sql files and folder to Dockerfile

### DIFF
--- a/fastapi/{{ cookiecutter.project_name }}/ci/docker/fastapi/Dockerfile
+++ b/fastapi/{{ cookiecutter.project_name }}/ci/docker/fastapi/Dockerfile
@@ -28,8 +28,10 @@ RUN poetry install --no-dev --no-root
 # Copy files
 COPY ./ci/docker/fastapi/entrypoint.sh /app/entrypoint.sh
 COPY ./ci/docker/fastapi/gunicorn.conf.py /app/gunicorn.conf.py
+{% if cookiecutter.sqlmodel == 'True' %}
 COPY ./alembic.ini /app/alembic.ini
 COPY ./migrations/ /app/migrations/
+{% endif %}
 COPY ./app/ /app/app/
 
 


### PR DESCRIPTION
In the [FastAPI project setup](https://create.intility.app/fastapi/getting-started/installation#create-fastapi-app) you get the choice of using SQLModel. If you opt out the Dockerfile should reflect this by not copying alembic and migrations files and folder.