### PR TITLE
fix(sentry): Changed sentry config to run with debug off in production.

### DIFF
--- a/dotnet/iwebapiproject/appsettings.Development.json
+++ b/dotnet/iwebapiproject/appsettings.Development.json
@@ -1,3 +1,6 @@
 {
-  "Serilog:MinimumLevel:Default": "Debug"
+  "Serilog:MinimumLevel:Default": "Debug",
+  "Sentry": {
+    "Debug": true
+  }
 }

--- a/dotnet/iwebapiproject/appsettings.json
+++ b/dotnet/iwebapiproject/appsettings.json
@@ -40,7 +40,7 @@
     "MinimumBreadcrumbLevel": "Debug",
     "MinimumEventLevel": "Warning",
     "AttachStackTrace": true,
-    "Debug": true,
+    "Debug": false,
     "DiagnosticsLevel": "Error"
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
[It's generally not recommended to turn it on in production, though turning debug mode on will not cause any safety concerns.](https://docs.sentry.io/platforms/dotnet/configuration/options/#debug)