### PR TITLE
feat(dotnet): updated template to use .net 6 as default version.

### DIFF
--- a/dotnet/iwebapi/.gitlab-ci.yml
+++ b/dotnet/iwebapi/.gitlab-ci.yml
@@ -25,7 +25,7 @@ default:
 
 build:
   stage: build
-  image: mcr.microsoft.com/dotnet/sdk:5.0
+  image: mcr.microsoft.com/dotnet/sdk:6.0
   script:
     - dotnet restore
     - cd Company.WebApplication1
@@ -37,7 +37,7 @@ build:
 
 test:
   stage: test
-  image: mcr.microsoft.com/dotnet/sdk:5.0
+  image: mcr.microsoft.com/dotnet/sdk:6.0
   script:
     - dotnet restore
     - dotnet test

--- a/dotnet/iwebapi/.template.config/template.json
+++ b/dotnet/iwebapi/.template.config/template.json
@@ -40,10 +40,6 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net5.0",
-          "description": "Target .NET 5"
-        },
-        {
           "choice": "net6.0",
           "description": "Target .NET 6"
         }

--- a/dotnet/iwebapi/.template.config/template.json
+++ b/dotnet/iwebapi/.template.config/template.json
@@ -41,11 +41,15 @@
       "choices": [
         {
           "choice": "net5.0",
-          "description": "Target net5.0"
+          "description": "Target .NET 5"
+        },
+        {
+          "choice": "net6.0",
+          "description": "Target .NET 6"
         }
       ],
-      "replaces": "net5.0",
-      "defaultValue": "net5.0"
+      "replaces": "net6.0",
+      "defaultValue": "net6.0"
     },
     "HostIdentifier": {
       "type": "bind",

--- a/dotnet/iwebapiproject/.gitlab-ci.yml
+++ b/dotnet/iwebapiproject/.gitlab-ci.yml
@@ -25,7 +25,7 @@ default:
 
 build:
   stage: build
-  image: mcr.microsoft.com/dotnet/sdk:5.0
+  image: mcr.microsoft.com/dotnet/sdk:6.0
   script:
     - dotnet restore
     - cd Company.WebApplication1
@@ -37,7 +37,7 @@ build:
 
 test:
   stage: test
-  image: mcr.microsoft.com/dotnet/sdk:5.0
+  image: mcr.microsoft.com/dotnet/sdk:6.0
   script:
     - dotnet restore
     - dotnet test

--- a/dotnet/iwebapiproject/.template.config/template.json
+++ b/dotnet/iwebapiproject/.template.config/template.json
@@ -30,10 +30,6 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net5.0",
-          "description": "Target .NET 5"
-        },
-        {
           "choice": "net6.0",
           "description": "Target .NET 6"
         }

--- a/dotnet/iwebapiproject/.template.config/template.json
+++ b/dotnet/iwebapiproject/.template.config/template.json
@@ -31,11 +31,15 @@
       "choices": [
         {
           "choice": "net5.0",
-          "description": "Target net5.0"
+          "description": "Target .NET 5"
+        },
+        {
+          "choice": "net6.0",
+          "description": "Target .NET 6"
         }
       ],
-      "replaces": "net5.0",
-      "defaultValue": "net5.0"
+      "replaces": "net6.0",
+      "defaultValue": "net6.0"
     },
     "auth": {
       "type": "parameter",

--- a/dotnet/iwebapiproject/Company.WebApplication1.csproj
+++ b/dotnet/iwebapiproject/Company.WebApplication1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.WebApplication1</RootNamespace>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
@@ -10,11 +10,11 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.11"/>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0"/>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0"/>
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="4.5.1" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="1.21.0"/>
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.21.1"/>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3"/>
     <PackageReference Include="Intility.Logging.AspNetCore" Version="1.0.3"/>
     <PackageReference Include="Intility.Extensions.Logging.Elasticsearch" Version="1.0.3"/>

--- a/dotnet/iwebapiproject/Dockerfile
+++ b/dotnet/iwebapiproject/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine AS publish
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS publish
 WORKDIR /src
 
 COPY *.csproj .
@@ -7,7 +7,7 @@ RUN dotnet restore
 COPY . .
 RUN dotnet publish -c Release -o /app --no-restore
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
 
 # if you use databases, these lines need to be uncommented
 # RUN apk add --no-cache icu-libs

--- a/dotnet/iwebapiproject/Dockerfile.CI
+++ b/dotnet/iwebapiproject/Dockerfile.CI
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:5.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
 
 # if you use databases, these lines need to be uncommented
 # RUN apk add --no-cache icu-libs


### PR DESCRIPTION
Added .net 6 as default version in the dotnet templates, and added .net 5 as a choice. 

closes #80