### PR TITLE
docs(fastapi): change git URL to not require SSH setup for easier use

### DIFF
--- a/docusaurus/fastapi/getting-started/installation.mdx
+++ b/docusaurus/fastapi/getting-started/installation.mdx
@@ -16,7 +16,7 @@ sidebar_position: 1
 ### Intility ``Cruft``
 You'll need [cruft](https://github.com/cruft/cruft) in order to use this template.
 ```bash
-python3.9 -m pip install cruft
+python -m pip install cruft
 ```
 
 :::info cruft
@@ -28,7 +28,7 @@ cruft is a templating language built on top of cookiecutter, which uses jinja te
 Use ``cruft`` to start your project.
 
 ```bash
-python3.9 -m cruft create git@github.com:Intility/templates.git --directory="fastapi"
+python -m cruft create https://github.com/Intility/templates.git --directory="fastapi"
 ```
 
 A few questions you will be prompted, here with a more verbose description:

--- a/fastapi/README.md
+++ b/fastapi/README.md
@@ -12,5 +12,5 @@ based on selections.
 
 
 ## Usage
-* `cruft create . --directory="fastapi"`
-* `cruft create git@github.com:Intility/templates.git --directory="fastapi"`
+* `cruft create . --directory="fastapi"` to use from source
+* `cruft create https://github.com/Intility/templates.git --directory="fastapi"` to use from GitHub


### PR DESCRIPTION
The previous URL required the user to have `ssh` set up for GitHub, which is an unnecessary requirement. 