### PR TITLE
fix(dotnet): fix time zone config in dockerfile

### DIFF
--- a/dotnet/iwebapi/Company.WebApplication1/Dockerfile
+++ b/dotnet/iwebapi/Company.WebApplication1/Dockerfile
@@ -15,7 +15,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
 
 # if you depend on timezones, these lines need to be uncommented
 # RUN apk add --no-cache tzdata
-# ENV TZ Europe/Oslo
+# ENV TZ=Europe/Oslo
 
 WORKDIR /app
 COPY --from=publish /app .

--- a/dotnet/iwebapi/Company.WebApplication1/Dockerfile.CI
+++ b/dotnet/iwebapi/Company.WebApplication1/Dockerfile.CI
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
 
 # if you depend on timezones, these lines need to be uncommented
 # RUN apk add --no-cache tzdata
-# ENV TZ Europe/Oslo
+# ENV TZ=Europe/Oslo
 
 WORKDIR /app
 COPY build .

--- a/dotnet/iworker/Company.Worker1/Dockerfile
+++ b/dotnet/iworker/Company.Worker1/Dockerfile
@@ -15,7 +15,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
 
 # if you depend on timezones, these lines need to be uncommented
 # RUN apk add --no-cache tzdata
-# ENV TZ Europe/Oslo
+# ENV TZ=Europe/Oslo
 
 WORKDIR /app
 COPY --from=publish /app .

--- a/dotnet/iworker/Company.Worker1/Dockerfile.CI
+++ b/dotnet/iworker/Company.Worker1/Dockerfile.CI
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
 
 # if you depend on timezones, these lines need to be uncommented
 # RUN apk add --no-cache tzdata
-# ENV TZ Europe/Oslo
+# ENV TZ=Europe/Oslo
 
 WORKDIR /app
 COPY build .


### PR DESCRIPTION
Changed the configuration for setting time zone in the dockerfile. 
TZ Europe/Oslo does not affect the pod because of a missing equal sign. 