### PR TITLE
fix: bump @testing-library/react to latest major

### DIFF
--- a/cra/cra-template-js/template.json
+++ b/cra/cra-template-js/template.json
@@ -2,7 +2,7 @@
   "package": {
     "dependencies": {
       "@testing-library/jest-dom": "^5.15.0",
-      "@testing-library/react": "^12.1.2",
+      "@testing-library/react": "^13.0.0",
       "@testing-library/user-event": "^13.5.0",
       "@intility/bifrost-react": "^2.13.0",
       "@intility/helm-version": "^1.2.1",

--- a/cra/cra-template/template.json
+++ b/cra/cra-template/template.json
@@ -2,7 +2,7 @@
   "package": {
     "dependencies": {
       "@testing-library/jest-dom": "^5.15.0",
-      "@testing-library/react": "^12.1.2",
+      "@testing-library/react": "^13.0.0",
       "@testing-library/user-event": "^13.5.0",
       "@types/jest": "^27.0.3",
       "@types/node": "^16.11.9",


### PR DESCRIPTION
This will fix the issue where @testing-library/react v12.x.x only supports react 17