### PR TITLE
Fix/fastapi/unused import

### DIFF
--- a/fastapi/{{ cookiecutter.project_name }}/app/core/config.py
+++ b/fastapi/{{ cookiecutter.project_name }}/app/core/config.py
@@ -1,7 +1,10 @@
 from typing import Literal
 
+{% if cookiecutter.authentication_strategy == 'FastAPI Azure Auth (default)' %}
 from pydantic import AnyHttpUrl, BaseSettings, Field
-
+{% else %}
+from pydantic import BaseSettings, Field
+{% endif %}
 
 class CustomBaseSettings(BaseSettings):
     """Configure .env settings for all our setting-classes"""


### PR DESCRIPTION
Minor fix to remove an import that's not in use, unless you use FastAPI-Azure-Auth