### PR TITLE
feat(dotnet): update dotnet from version 6 to version 7

### DIFF
--- a/dotnet/Intility.Templates.csproj
+++ b/dotnet/Intility.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.4.1</PackageVersion>
+    <PackageVersion>1.4.7</PackageVersion>
     <PackageId>Intility.Templates</PackageId>
     <Title>Intility Templates</Title>
     <Authors>Intility</Authors>

--- a/dotnet/Intility.Templates.csproj
+++ b/dotnet/Intility.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.4.7</PackageVersion>
+    <PackageVersion>1.5.0</PackageVersion>
     <PackageId>Intility.Templates</PackageId>
     <Title>Intility Templates</Title>
     <Authors>Intility</Authors>

--- a/dotnet/iwebapi/.gitlab-ci.yml
+++ b/dotnet/iwebapi/.gitlab-ci.yml
@@ -25,7 +25,7 @@ default:
 
 build:
   stage: build
-  image: mcr.microsoft.com/dotnet/sdk:6.0
+  image: mcr.microsoft.com/dotnet/sdk:7.0
   script:
     - dotnet restore
     - cd Company.WebApplication1
@@ -37,7 +37,7 @@ build:
 
 test:
   stage: test
-  image: mcr.microsoft.com/dotnet/sdk:6.0
+  image: mcr.microsoft.com/dotnet/sdk:7.0
   script:
     - dotnet restore
     - dotnet test
@@ -45,7 +45,7 @@ test:
 
 analyze:
   stage: analyze
-  image: nosinovacao/dotnet-sonar:latest
+  image: ghcr.io/nosinovacao/dotnet-sonar:latest
   script:
     - dotnet restore
     - dotnet /sonar-scanner/SonarScanner.MSBuild.dll begin 

--- a/dotnet/iwebapi/.template.config/template.json
+++ b/dotnet/iwebapi/.template.config/template.json
@@ -47,12 +47,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net6.0",
-          "description": "Target .NET 6"
+          "choice": "net7.0",
+          "description": "Target .NET 7"
         }
       ],
-      "replaces": "net6.0",
-      "defaultValue": "net6.0"
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
     },
     "HostIdentifier": {
       "type": "bind",

--- a/dotnet/iwebapi/Company.WebApplication1/Company.WebApplication1.csproj
+++ b/dotnet/iwebapi/Company.WebApplication1/Company.WebApplication1.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>aspnet-Company.WebApplication1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
@@ -12,14 +12,13 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.9"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0"/>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0"/>
-    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.1.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="1.25.3"/>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0"/>
-    <PackageReference Include="Intility.Logging.AspNetCore" Version="1.3.1"/>
-    <PackageReference Include="Intility.Extensions.Logging.Elasticsearch" Version="1.3.1"/>
-    <PackageReference Include="Intility.Extensions.Logging.Sentry" Version="1.3.1"/>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.2.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="1.25.10" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Intility.Logging.AspNetCore" Version="1.3.1" />
+    <PackageReference Include="Intility.Extensions.Logging.Elasticsearch" Version="1.3.1" />
+    <PackageReference Include="Intility.Extensions.Logging.Sentry" Version="1.3.1" />
   </ItemGroup>
 </Project>

--- a/dotnet/iwebapi/Company.WebApplication1/Dockerfile
+++ b/dotnet/iwebapi/Company.WebApplication1/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS publish
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
 WORKDIR /src
 
 COPY *.csproj .
@@ -7,7 +7,7 @@ RUN dotnet restore
 COPY . .
 RUN dotnet publish -c Release -o /app --no-restore
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine
 
 # if you use databases, these lines need to be uncommented
 # RUN apk add --no-cache icu-libs

--- a/dotnet/iwebapi/Company.WebApplication1/Dockerfile.CI
+++ b/dotnet/iwebapi/Company.WebApplication1/Dockerfile.CI
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine
 
 # if you use databases, these lines need to be uncommented
 # RUN apk add --no-cache icu-libs

--- a/dotnet/iworker/.gitlab-ci.yml
+++ b/dotnet/iworker/.gitlab-ci.yml
@@ -25,7 +25,7 @@ default:
 
 build:
   stage: build
-  image: mcr.microsoft.com/dotnet/sdk:6.0
+  image: mcr.microsoft.com/dotnet/sdk:7.0
   script:
     - dotnet restore
     - cd Company.Worker1
@@ -37,7 +37,7 @@ build:
 
 test:
   stage: test
-  image: mcr.microsoft.com/dotnet/sdk:6.0
+  image: mcr.microsoft.com/dotnet/sdk:7.0
   script:
     - dotnet restore
     - dotnet test
@@ -45,7 +45,7 @@ test:
 
 analyze:
   stage: analyze
-  image: nosinovacao/dotnet-sonar:latest
+  image: ghcr.io/nosinovacao/dotnet-sonar:latest
   script:
     - dotnet restore
     - dotnet /sonar-scanner/SonarScanner.MSBuild.dll begin 

--- a/dotnet/iworker/.template.config/template.json
+++ b/dotnet/iworker/.template.config/template.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/template",
   "author": "Intility",
-  "classifications": ["Intility", "Worker", "Web"],
+  "classifications": [ "Intility", "Worker", "Web" ],
   "name": "Intility Worker",
   "description": "A solution template for creating Intility Worker Services.",
   "identity": "Intility.Templates.WorkerSolution.CSharp",
@@ -12,13 +12,17 @@
   },
   "sourceName": "Company.Worker1",
   "preferNameDirectory": true,
-  "guids": ["53bc9b9d-9d6a-45d4-8429-2a2761773502"],
+  "guids": [
+    "0E62310C-D76A-4681-9926-B1BFFDC379FC",
+    "6B4D25B3-1CA5-49A7-BD85-EDC0FFF3AC14",
+    "53bc9b9d-9d6a-45d4-8429-2a2761773502"
+  ],
   "sources": [
     {
       "modifiers": [
         {
           "condition": "(windir == 'C:\\Windows')",
-          "exclude": ["Company.Worker1/Properties/launchSettings.json"]
+          "exclude": [ "Company.Worker1/Properties/launchSettings.json" ]
         },
         {
           "condition": "(HostIdentifier != 'dotnetcli' && !projectOnly)",
@@ -51,12 +55,12 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "net6.0",
-          "description": "Target .NET 6"
+          "choice": "net7.0",
+          "description": "Target .NET 7"
         }
       ],
-      "replaces": "net6.0",
-      "defaultValue": "net6.0"
+      "replaces": "net7.0",
+      "defaultValue": "net7.0"
     },
     "skipRestore": {
       "type": "parameter",

--- a/dotnet/iworker/Company.Worker1/Company.Worker1.csproj
+++ b/dotnet/iworker/Company.Worker1/Company.Worker1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>dotnet-Company.Worker1-53bc9b9d-9d6a-45d4-8429-2a2761773502</UserSecretsId>
@@ -10,9 +10,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Identity" Version="1.7.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.1.0" />
+		<PackageReference Include="Azure.Identity" Version="1.8.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.0" />
+		<PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.2.0" />
 		<PackageReference Include="Intility.Logging.AspNetCore" Version="1.3.1"/>
 		<PackageReference Include="Intility.Extensions.Logging.Elasticsearch" Version="1.3.1"/>
 		<PackageReference Include="Intility.Extensions.Logging.Sentry" Version="1.3.1"/>

--- a/dotnet/iworker/Company.Worker1/Dockerfile
+++ b/dotnet/iworker/Company.Worker1/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine AS publish
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS publish
 WORKDIR /src
 
 COPY *.csproj .
@@ -7,7 +7,7 @@ RUN dotnet restore
 COPY . .
 RUN dotnet publish -c Release -o /app --no-restore
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine
 
 # if you use databases, these lines need to be uncommented
 # RUN apk add --no-cache icu-libs

--- a/dotnet/iworker/Company.Worker1/Dockerfile.CI
+++ b/dotnet/iworker/Company.Worker1/Dockerfile.CI
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine
 
 # if you use databases, these lines need to be uncommented
 # RUN apk add --no-cache icu-libs


### PR DESCRIPTION
Updated iwebapi and iworker to use the newest version of dotnet.

I also had to change the image used in the analyze stage from `nosinovacao/dotnet-sonar:latest` to `ghcr.io/nosinovacao/dotnet-sonar:latest`.