### PR TITLE
feat: prefer `.vscode` folder over `app.code-workspace` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,4 +63,3 @@ nodejs/generators/app/templates/reports
 
 # Visual Studio 2015/2017/2022 cache/options directory
 .vs/
-.vscode

--- a/docusaurus/react/getting-started/installation.mdx
+++ b/docusaurus/react/getting-started/installation.mdx
@@ -13,6 +13,8 @@ sidebar_position: 1
 
 ## Create App
 
+Run these commands in your terminal.
+
 ```bash
 npx degit intility/templates/react my-app
 cd my-app
@@ -20,10 +22,10 @@ cd my-app
 npm install
 ```
 
-Run it in your terminal, and then open the Visual Studio Code Workspace with the following command.
+Open the project folder in Visual Studio Code. On windows, you can do so with the following command.
 
 ```bash
-code app.code-workspace
+code .
 ```
 
 You can now start coding by running the start script.

--- a/docusaurus/react/getting-started/installation.mdx
+++ b/docusaurus/react/getting-started/installation.mdx
@@ -22,7 +22,7 @@ cd my-app
 npm install
 ```
 
-Open the project folder in Visual Studio Code. On windows, you can do so with the following command.
+Open the project folder in Visual Studio Code with the following command.
 
 ```bash
 code .

--- a/docusaurus/react/getting-started/project-overview.mdx
+++ b/docusaurus/react/getting-started/project-overview.mdx
@@ -7,6 +7,9 @@ Depending on which template you chose,
 your project structure will look more or less like the following:
 
 ```
+├── .vscode
+│   ├── extensions.json
+│   └── settings.json
 ├── chart
 │   ├── templates
 │   │   ├── _helpers.tpl
@@ -50,7 +53,6 @@ your project structure will look more or less like the following:
 ├── Dockerfile
 ├── Dockerfile.CI
 ├── README.md
-├── app.code-workspace
 ├── index.html
 ├── package.json
 ├── tsconfig.json

--- a/react/.gitignore
+++ b/react/.gitignore
@@ -15,8 +15,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
-!.vscode/extensions.json
 .idea
 .DS_Store
 *.suo

--- a/react/.vscode/extensions.json
+++ b/react/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+      "swellaby.node-pack",
+      "esbenp.prettier-vscode",
+      "intility.vscode-backstage",
+      "redhat.vscode-yaml"
+    ]
+  }

--- a/react/.vscode/settings.json
+++ b/react/.vscode/settings.json
@@ -1,10 +1,4 @@
 {
-  "folders": [
-    {
-      "path": "."
-    }
-  ],
-  "settings": {
     "files.eol": "\n",
     "files.associations": {
       "*.js": "javascript",
@@ -35,13 +29,4 @@
       "editor.defaultFormatter": "dbaeumer.vscode-eslint"
     },
     "typescript.tsdk": "node_modules/typescript/lib"
-  },
-  "extensions": {
-    "recommendations": [
-      "swellaby.node-pack",
-      "esbenp.prettier-vscode",
-      "intility.vscode-backstage",
-      "redhat.vscode-yaml"
-    ]
   }
-}

--- a/react/README.md
+++ b/react/README.md
@@ -44,6 +44,8 @@ React
 
 ## Getting Started
 
+### First-time setup
+
 <!--
 Provide step by step instructions that will allow a new contributor to get a copy of the project up and running on their local machine.
 Installation of common development tools such as `git`, `docker` and IDEs can be covered here, but is not necessary.
@@ -51,6 +53,8 @@ Installation of common development tools such as `git`, `docker` and IDEs can be
 The granularity and extent of these instructions will depend on the size and type of the project,
 but may extend to things such as platform specific steps, etc.
 -->
+
+Clone the repository, then install dependencies with `npm install`
 
 ### Running the project
 
@@ -68,7 +72,7 @@ Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 The page will reload if you make edits.<br />
 You will also see any lint errors in the console.
 
-## `npm test`
+### `npm test`
 
 Launches the test runner in the interactive watch mode.
 


### PR DESCRIPTION
- users are no longer required to manually open the workspace file
- vscode title bar now displays project name instead of "app"