### PR TITLE
fix(dotnet): block all users that has a claim with type "idp"

### DIFF
--- a/dotnet/Intility.Templates.csproj
+++ b/dotnet/Intility.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.5.1</PackageVersion>
+    <PackageVersion>1.5.2</PackageVersion>
     <PackageId>Intility.Templates</PackageId>
     <Title>Intility Templates</Title>
     <Authors>Intility</Authors>

--- a/dotnet/iwebapi/Company.WebApplication1/Extensions/AuthorizationExtensions.cs
+++ b/dotnet/iwebapi/Company.WebApplication1/Extensions/AuthorizationExtensions.cs
@@ -19,10 +19,12 @@ public class NonGuestsHandler : AuthorizationHandler<NonGuestsRequirement>
     protected override Task HandleRequirementAsync(
         AuthorizationHandlerContext context, NonGuestsRequirement requirement)
     {
-        var issuer = context.User.FindFirst(c => c.Type == "iss");
-        var tenantId = context.User.FindFirst(c => c.Type == ClaimConstants.TenantId);
+        // This method checks for the presence of a claim with the type "idp" in the user's context. 
+        // If the claim is not found, it grants the specified requirement. This ensures that no 
+        // guest users in an Azure tenant can access this resource. 
 
-        if (issuer != null && tenantId != null && issuer.Value.Contains(tenantId.Value))
+        var idp = context.User.FindFirst(c => c.Type == "idp");
+        if (idp == null)
         {
             context.Succeed(requirement);
         }

--- a/dotnet/iwebapi/Company.WebApplication1/Extensions/AuthorizationExtensions.cs
+++ b/dotnet/iwebapi/Company.WebApplication1/Extensions/AuthorizationExtensions.cs
@@ -23,7 +23,7 @@ public class NonGuestsHandler : AuthorizationHandler<NonGuestsRequirement>
         // If the claim is not found, it grants the specified requirement. This ensures that no 
         // guest users in an Azure tenant can access this resource. 
 
-        var idp = context.User.FindFirst(c => c.Type == "idp");
+        var idp = context.User.FindFirst(c => c.Type == "http://schemas.microsoft.com/identity/claims/identityprovider");
         if (idp == null)
         {
             context.Succeed(requirement);


### PR DESCRIPTION
Update the NonGuestHandler to block all users that has a claim with the type "idp". 