### PR TITLE
fix(dotnet): replace deprecated api versioning nuget

### DIFF
--- a/dotnet/iwebapi/Company.WebApplication1/Company.WebApplication1.csproj
+++ b/dotnet/iwebapi/Company.WebApplication1/Company.WebApplication1.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="6.1.1" />
     <PackageReference Include="Microsoft.Identity.Web" Version="2.15.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="Intility.Logging.AspNetCore" Version="1.5.0" />
-    <PackageReference Include="Intility.Extensions.Logging.Elasticsearch" Version="1.5.0" />
-    <PackageReference Include="Intility.Extensions.Logging.Sentry" Version="1.5.0" />
+    <PackageReference Include="Intility.Logging.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Intility.Extensions.Logging.Elasticsearch" Version="2.0.0" />
+    <PackageReference Include="Intility.Extensions.Logging.Sentry" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/dotnet/iwebapi/Company.WebApplication1/Company.WebApplication1.csproj
+++ b/dotnet/iwebapi/Company.WebApplication1/Company.WebApplication1.csproj
@@ -12,10 +12,10 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc" Version="7.1.0" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="7.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.13" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
-    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="6.1.1" />
     <PackageReference Include="Microsoft.Identity.Web" Version="2.15.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Intility.Logging.AspNetCore" Version="1.5.0" />

--- a/dotnet/iwebapi/Company.WebApplication1/Controllers/V1/WeatherForecastController.cs
+++ b/dotnet/iwebapi/Company.WebApplication1/Controllers/V1/WeatherForecastController.cs
@@ -1,9 +1,6 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
+﻿using Asp.Versioning;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Identity.Web.Resource;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Company.WebApplication1.Controllers.V1;
 

--- a/dotnet/iwebapi/Company.WebApplication1/Program.cs
+++ b/dotnet/iwebapi/Company.WebApplication1/Program.cs
@@ -64,9 +64,7 @@ builder.Services.AddApiVersioning(options =>
 {
     options.ReportApiVersions = true;
     options.AssumeDefaultVersionWhenUnspecified = true;
-});
-
-builder.Services.AddVersionedApiExplorer(options =>
+}).AddApiExplorer(options =>
 {
     // add the versioned api explorer, which also adds IApiVersionDescriptionProvider service
     // note: the specified format code will format the version as "'v'major[.minor][-status]"

--- a/dotnet/iwebapi/Company.WebApplication1/Program.cs
+++ b/dotnet/iwebapi/Company.WebApplication1/Program.cs
@@ -58,6 +58,7 @@ builder.Services.AddCors(options =>
 
 builder.Services.AddHealthChecks();
 
+builder.Services.AddHttpContextAccessor();
 builder.Services.AddControllers();
 
 builder.Services.AddApiVersioning(options =>

--- a/dotnet/iwebapi/Company.WebApplication1/Program.cs
+++ b/dotnet/iwebapi/Company.WebApplication1/Program.cs
@@ -58,7 +58,6 @@ builder.Services.AddCors(options =>
 
 builder.Services.AddHealthChecks();
 
-builder.Services.AddHttpContextAccessor();
 builder.Services.AddControllers();
 
 builder.Services.AddApiVersioning(options =>

--- a/dotnet/iwebapi/Company.WebApplication1/Swagger/SwaggerGenConfigurator.cs
+++ b/dotnet/iwebapi/Company.WebApplication1/Swagger/SwaggerGenConfigurator.cs
@@ -1,13 +1,8 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Reflection;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
+using Asp.Versioning.ApiExplorer;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using System.Reflection;
 
 namespace Company.WebApplication1.Swagger;
 

--- a/dotnet/iwebapi/Company.WebApplication1/Swagger/SwaggerUIConfigurator.cs
+++ b/dotnet/iwebapi/Company.WebApplication1/Swagger/SwaggerUIConfigurator.cs
@@ -1,6 +1,4 @@
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.Extensions.Configuration;
+using Asp.Versioning.ApiExplorer;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.SwaggerUI;
 

--- a/dotnet/iworker/Company.Worker1/Company.Worker1.csproj
+++ b/dotnet/iworker/Company.Worker1/Company.Worker1.csproj
@@ -12,9 +12,9 @@
 	<ItemGroup>
 		<PackageReference Include="Azure.Identity" Version="1.10.3" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-		<PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="6.1.0" />
-		<PackageReference Include="Intility.Logging.AspNetCore" Version="1.5.0"/>
-		<PackageReference Include="Intility.Extensions.Logging.Elasticsearch" Version="1.5.0"/>
-		<PackageReference Include="Intility.Extensions.Logging.Sentry" Version="1.5.0"/>
+		<PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="6.1.1" />
+		<PackageReference Include="Intility.Logging.AspNetCore" Version="2.0.0"/>
+		<PackageReference Include="Intility.Extensions.Logging.Elasticsearch" Version="2.0.0"/>
+		<PackageReference Include="Intility.Extensions.Logging.Sentry" Version="2.0.0"/>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
replaced the Mvc.Versioning nuget with the new Asp.Versioning.Mvc nuget

closes #311