### PR TITLE
feat: add startup probe

### DIFF
--- a/dotnet/iwebapi/Company.WebApplication1/chart/templates/deployment.yaml
+++ b/dotnet/iwebapi/Company.WebApplication1/chart/templates/deployment.yaml
@@ -41,9 +41,9 @@ spec:
             httpGet:
               path: /health
               port: http
-            failureThreshold: 30
+            failureThreshold: 5
             initialDelaySeconds: 2
-            timeoutSeconds: 4
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/dotnet/iwebapi/Company.WebApplication1/chart/templates/deployment.yaml
+++ b/dotnet/iwebapi/Company.WebApplication1/chart/templates/deployment.yaml
@@ -37,6 +37,13 @@ spec:
             httpGet:
               path: /health
               port: http
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            failureThreshold: 30
+            initialDelaySeconds: 2
+            timeoutSeconds: 4
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:


### PR DESCRIPTION
Added startup probe [kubernetes docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/). I changed the default initialDelaySeconds to 4 seconds instead of 1. I feel like the 1 second is a little short?

I also changed the timeoutSeconds to 5 seconds.

The config should now wait 2 seconds before trying, wait at least 5 seconds before failing and trying 5 times. 