### PR TITLE
chore: add claude code local settings to .gitignore of iwebapi, iworker and react

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ nodejs/generators/app/templates/reports
 
 # Visual Studio 2015/2017/2022 cache/options directory
 .vs/
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/dotnet/iwebapi/.gitignore
+++ b/dotnet/iwebapi/.gitignore
@@ -386,3 +386,6 @@ FodyWeavers.xsd
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/dotnet/iworker/.gitignore
+++ b/dotnet/iworker/.gitignore
@@ -386,3 +386,6 @@ FodyWeavers.xsd
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# Claude Code local settings
+.claude/settings.local.json


### PR DESCRIPTION
https://docs.anthropic.com/en/docs/claude-code/settings

Claude-code may create a .claude/settings.local.json when users approve certain action in a directory. These are settings for the user, and are not meant to be commited directly to source. Claude is supposed to add a global ignore in the root directory of the user's computer, but we shouldn't trust this to do it correctly. It has already proven to be bugged on windows. 