### PR TITLE
fix(dotnet): correct template parameter names to avoid conflicts

### DIFF
--- a/docusaurus/dotnet/4-setup/1-create-project.mdx
+++ b/docusaurus/dotnet/4-setup/1-create-project.mdx
@@ -53,13 +53,13 @@ dotnet run --project MyApiService/MyApiService.csproj
 
 **Advanced options:**
 
-If you only want to create a project (without a solution), use the `--project` argument.  
+If you only want to create a project (without a solution), use the `--projectOnly` argument.
 :::info
-The `--project` parameter will skip the creation of ArgoCD, k8s deployment and release-please. The parameters `--argo-project`, `--openshift-namespace` and `--github-repo-url` will be ignored.
+The `--projectOnly` parameter will skip the creation of ArgoCD, k8s deployment and release-please. The parameters `--argo-project`, `--openshift-namespace` and `--github-repo-url` will be ignored.
 :::
 
 ```shell
-dotnet new iwebapi -o MyApiService --project
+dotnet new iwebapi -o MyApiService --projectOnly
 ```
 
 To see all available parameters:
@@ -128,18 +128,18 @@ dotnet run --project MyWorkerService/MyWorkerService.csproj
 **Advanced options:**
 
 :::info
-The `--project` parameter will skip the creation of ArgoCD, k8s deployment and release-please. The parameters `--argo-project`, `--openshift-namespace` and `--github-repo-url` will be ignored.
+The `--projectOnly` parameter will skip the creation of ArgoCD, k8s deployment and release-please. The parameters `--argo-project`, `--openshift-namespace` and `--github-repo-url` will be ignored.
 :::
 
 ```shell
-dotnet new iworker -o MyWorkerService --project
+dotnet new iworker -o MyWorkerService --projectOnly
 ```
 
 For scheduled tasks, you can create a Kubernetes CronJob instead of a Deployment:
 
 ```shell
 # Create a worker service configured as a scheduled job
-dotnet new iworker -o MyScheduledWorker --cronJob true
+dotnet new iworker -o MyScheduledWorker --cronJob
 ```
 
 To see all available parameters:
@@ -187,8 +187,8 @@ These parameters are available for both templates:
 | Parameter                    | Description                                                                                 |
 | ---------------------------- | ------------------------------------------------------------------------------------------- |
 | `-o, --output`               | Output directory for the generated project                                                  |
-| `-p, --project`              | Creates only the project without a solution file, ArgoCD, k8s deployment and release-please |
-| `-f, --framework`            | Target framework version (defaults to net9.0)                                               |
+| `-p, --projectOnly`          | Creates only the project without a solution file, ArgoCD, k8s deployment and release-please |
+| `-f, --framework`            | Target framework version (defaults to net10.0)                                              |
 | `-ap, --argo-project`        | Argo Project Name (e.g. AppServices). This is the "folder" for your applications in ArgoCD  |
 | `-on, --openshift-namespace` | OpenShift Namespace (e.g. aa-appservices-dev)                                               |
 | `-gru, --github-repo-url`    | GitHub Repository URL                                                                       |
@@ -214,9 +214,9 @@ The following parameters are specific to the `iwebapi` template:
 
 The following parameters are specific to the `iworker` template:
 
-| Parameter    | Description                                                          |
-| ------------ | -------------------------------------------------------------------- |
-| `-c, --cron` | Set to `true` to create a Kubernetes CronJob instead of a Deployment |
+| Parameter       | Description                                                       |
+| --------------- | ----------------------------------------------------------------- |
+| `-c, --cronJob` | Creates a Kubernetes CronJob instead of a continuous Deployment   |
 
 </details>
 

--- a/dotnet/Intility.Templates.csproj
+++ b/dotnet/Intility.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>2.1.1</PackageVersion>
+    <PackageVersion>2.1.2</PackageVersion>
     <PackageId>Intility.Templates</PackageId>
     <Title>Intility Templates</Title>
     <Authors>Intility</Authors>

--- a/dotnet/iwebapi/.template.config/dotnetcli.host.json
+++ b/dotnet/iwebapi/.template.config/dotnetcli.host.json
@@ -26,7 +26,7 @@
       "shortName": ""
     },
     "projectOnly": {
-      "longName": "project",
+      "longName": "projectOnly",
       "shortName": "p"
     },
     "UserSecretsId": {
@@ -47,6 +47,6 @@
   },
   "usageExamples": [
     "--client-id \"11111111-1111-1111-11111111111111111\" --tenant-id \"9b5ff18e-53c0-45a2-8bc2-9c0c8f60b2c6\"",
-    "-p --no-restore"
+    "--projectOnly --no-restore"
   ]
 }

--- a/dotnet/iworker/.template.config/dotnetcli.host.json
+++ b/dotnet/iworker/.template.config/dotnetcli.host.json
@@ -10,11 +10,11 @@
       "shortName": ""
     },
     "projectOnly": {
-      "longName": "project",
+      "longName": "projectOnly",
       "shortName": "p"
     },
     "cronJob": {
-      "longName": "cron",
+      "longName": "cronJob",
       "shortName": "c"
     },
     "ArgoProject": {
@@ -30,5 +30,5 @@
       "shortName": "gru"
     }
   },
-  "usageExamples": ["--cron", "-p --no-restore"]
+  "usageExamples": ["--cronJob", "--projectOnly --no-restore"]
 }


### PR DESCRIPTION
## Summary
- Fixed template parameter naming conflicts with built-in dotnet CLI options
- Changed `--project` → `--projectOnly` to avoid conflict with built-in `--project` option
- Changed `--cron` → `--cronJob` for consistency with symbol name
- Updated documentation to reflect correct parameter usage
- Bumped package version to 2.1.2

## Background
The built-in `--project <PROJECT_PATH>` option is used for context evaluation in item templates, while our `projectOnly` parameter controls the output structure (project-only vs full solution with CI/CD, k8s, ArgoCD, etc.). These serve different purposes and cannot be combined.

## Changes
- Updated `dotnetcli.host.json` for both `iwebapi` and `iworker` templates
- Updated documentation in `docusaurus/dotnet/4-setup/1-create-project.mdx`
- Bumped version in `Intility.Templates.csproj` from 2.1.1 to 2.1.2

## Testing
Verified that `dotnet new iworker --projectOnly --cronJob -o TestProject` now works correctly without parameter conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)