### PR TITLE
fix(dotnet): update nugets for dotnet worker and api

### DIFF
--- a/dotnet/Intility.Templates.csproj
+++ b/dotnet/Intility.Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>2.1.2</PackageVersion>
+    <PackageVersion>2.1.3</PackageVersion>
     <PackageId>Intility.Templates</PackageId>
     <Title>Intility Templates</Title>
     <Authors>Intility</Authors>

--- a/dotnet/iwebapi/Company.WebApplication1/Company.WebApplication1.csproj
+++ b/dotnet/iwebapi/Company.WebApplication1/Company.WebApplication1.csproj
@@ -21,16 +21,16 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
-    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.0" />
+    <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.1" />
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.1" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="4.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.0.1" />
-    <PackageReference Include="Intility.Logging.AspNetCore" Version="3.1.1" />
-    <PackageReference Include="Intility.Extensions.Logging.Elasticsearch" Version="3.1.1" />
-    <PackageReference Include="Intility.Extensions.Logging.Sentry" Version="3.1.1" />
-    <PackageReference Include="Intility.Authorization.Azure.GuestPolicies" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageReference Include="Intility.Logging.AspNetCore" Version="3.1.3" />
+    <PackageReference Include="Intility.Extensions.Logging.Elasticsearch" Version="3.1.3" />
+    <PackageReference Include="Intility.Extensions.Logging.Sentry" Version="3.1.3" />
+    <PackageReference Include="Intility.Authorization.Azure.GuestPolicies" Version="2.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/iworker/Company.Worker1/Company.Worker1.csproj
+++ b/dotnet/iworker/Company.Worker1/Company.Worker1.csproj
@@ -20,13 +20,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Identity" Version="1.17.1" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
 		<PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.4.0" />
-		<PackageReference Include="Intility.Logging.AspNetCore" Version="3.1.1" />
-		<PackageReference Include="Intility.Extensions.Logging.Elasticsearch" Version="3.1.1" />
-		<PackageReference Include="Intility.Extensions.Logging.Sentry" Version="3.1.1" />
-		<PackageReference Include="Microsoft.Identity.Abstractions" Version="9.6.0" />
-		<PackageReference Include="Microsoft.Identity.Web" Version="4.1.1" />
+		<PackageReference Include="Intility.Logging.AspNetCore" Version="3.1.3" />
+		<PackageReference Include="Intility.Extensions.Logging.Elasticsearch" Version="3.1.3" />
+		<PackageReference Include="Intility.Extensions.Logging.Sentry" Version="3.1.3" />
+		<PackageReference Include="Microsoft.Identity.Abstractions" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Identity.Web" Version="4.2.0" />
 	</ItemGroup>
 
 	<Target Name="OutputContainerDigest" AfterTargets="PublishContainer" Condition=" '$(GITHUB_OUTPUT)' != '' ">


### PR DESCRIPTION
WebAPI updates:
   - Asp.Versioning.Mvc: 8.1.0 → 8.1.1
   - Asp.Versioning.Mvc.ApiExplorer: 8.1.0 → 8.1.1
   - Microsoft.AspNetCore.Authentication.JwtBearer: 10.0.0 → 10.0.1
   - Microsoft.Identity.Web: 4.0.1 → 4.2.0
   - Swashbuckle.AspNetCore: 10.0.1 → 10.1.0
   - Intility.Logging.AspNetCore: 3.1.1 → 3.1.3
   - Intility.Extensions.Logging.Elasticsearch: 3.1.1 → 3.1.3
   - Intility.Extensions.Logging.Sentry: 3.1.1 → 3.1.3
   - Intility.Authorization.Azure.GuestPolicies: 2.2.0 → 2.2.1

   Worker updates:
   - Microsoft.Extensions.Hosting: 10.0.0 → 10.0.1
   - Intility.Logging.AspNetCore: 3.1.1 → 3.1.3
   - Intility.Extensions.Logging.Elasticsearch: 3.1.1 → 3.1.3
   - Intility.Extensions.Logging.Sentry: 3.1.1 → 3.1.3
   - Microsoft.Identity.Abstractions: 9.6.0 → 10.0.0
   - Microsoft.Identity.Web: 4.1.1 → 4.2.0

   Supersedes #505 and #506