### PR TITLE
chore(react): harden npm config against supply chain attacks

### DIFF
--- a/react/.npmrc
+++ b/react/.npmrc
@@ -1,2 +1,8 @@
 # https://github.com/orgs/intility/discussions/13
 registry=https://npm.intility.com
+
+# Supply chain hardening
+ignore-scripts=true
+allow-git=none
+allow-remote=none
+min-release-age=1


### PR DESCRIPTION
## Summary
- Adds four supply-chain hardening options to `react/.npmrc`:
  - `ignore-scripts=true` — skips pre/post/install lifecycle scripts
  - `allow-git=none` — blocks git-URL dependencies
  - `allow-remote=none` — blocks tarball-URL dependencies
  - `min-release-age=1` — refuses package versions younger than 1 day

Motivated by recent npm supply-chain incidents. These options require npm ≥ 11.5; older clients will silently ignore them.

## Test plan
- [ ] Wipe `react/node_modules` and run a clean `npm install` in the template
- [ ] Run `npm run build` to confirm no install-script dependency was relying on lifecycle scripts
- [ ] Run `npm run test` and `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)