### PR TITLE
fix(dotnet): pin Azure.Identity 1.21.0 in iwebapi template

### DIFF
--- a/dotnet/iwebapi/Company.WebApplication1/Company.WebApplication1.csproj
+++ b/dotnet/iwebapi/Company.WebApplication1/Company.WebApplication1.csproj
@@ -23,6 +23,8 @@
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
+    <!-- Explicit pin: Azure.Core >=1.53.0 type-forwards credential types. Azure.Identity <=1.20.0 also defines them (CS0433). 1.21.0 is a forwarding shim. See azure-sdk-for-net#58822. -->
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="8.6.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.3" />

--- a/dotnet/iwebapi/Company.WebApplication1/packages.lock.json
+++ b/dotnet/iwebapi/Company.WebApplication1/packages.lock.json
@@ -20,6 +20,15 @@
           "Asp.Versioning.Mvc": "10.0.1"
         }
       },
+      "Azure.Identity": {
+        "type": "Direct",
+        "requested": "[1.21.0, )",
+        "resolved": "1.21.0",
+        "contentHash": "GeFv8sGwRKvDKwI2WFy8r0mhmlxEVZg24Sit2NogTjiSO8RVjllWM65OT6e1sKjOvG8V74y7hAbaELUUPjZQSw==",
+        "dependencies": {
+          "Azure.Core": "1.53.0"
+        }
+      },
       "Intility.Authorization.Azure.GuestPolicies": {
         "type": "Direct",
         "requested": "[2.2.6, )",
@@ -140,16 +149,6 @@
         "contentHash": "ClG33fUhOW18zpAOieIcbb84EfEWe0Ey6pTYjKoMezSrCYmdLbxW03FSuoAWxVTJyu1JEzuNYai08yeSQi6Xvg==",
         "dependencies": {
           "Azure.Core": "1.60.0"
-        }
-      },
-      "Azure.Identity": {
-        "type": "Transitive",
-        "resolved": "1.17.2",
-        "contentHash": "WLI9tc1NwOzvncfSfut5w/qv4f4ZC+l4JK0XXNZCMjZn6MDAgytZsNAJBI3MJs+XcPGBikedYv/dLMXryLQBeg==",
-        "dependencies": {
-          "Azure.Core": "1.50.0",
-          "Microsoft.Identity.Client": "4.83.1",
-          "Microsoft.Identity.Client.Extensions.Msal": "4.83.1"
         }
       },
       "Azure.Messaging.EventGrid": {


### PR DESCRIPTION
## Summary

The iwebapi template fails to build with:

```
error CS0433: The type 'DefaultAzureCredential' exists in both 'Azure.Core, Version=1.60.0.0' and 'Azure.Identity, Version=1.17.2.0'
```

**Root cause**
- `Azure.Data.AppConfiguration 1.11.0` (via `Microsoft.Azure.AppConfiguration.AspNetCore 8.6.0`) pulls `Azure.Core 1.60.0`, which type-forwards the credential types.
- `Microsoft.Identity.Web.Certificate 4.14.2` pulls `Azure.Identity 1.17.2`, which still defines them.
- The iworker template already pins `Azure.Identity 1.21.0` (since #608). The iwebapi template had no explicit reference.

**Fix**
- Add explicit `Azure.Identity 1.21.0` pin to `Company.WebApplication1.csproj`. 1.21.0 is a forwarding shim that removes the duplicate.
- Regenerate `packages.lock.json`.

See https://github.com/Azure/azure-sdk-for-net/issues/58822

## Test plan

- [x] `dotnet build` on `dotnet/iwebapi/Company.WebApplication1` succeeds locally
- [x] Resolved graph: `Azure.Core/1.60.0` + `Azure.Identity/1.21.0`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)